### PR TITLE
added nose task

### DIFF
--- a/tekton/tasks.yaml
+++ b/tekton/tasks.yaml
@@ -2,51 +2,34 @@
 apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
-  name: echo
+  name: nose
 spec:
-  description: This task will echo the message.
-  params:
-    - name: message
-      description: The message to echo
-      type: string
-  steps:
-    - name: echo-message
-      image: alpine:3
-      command: [/bin/echo]
-      args: ["$(params.message)"]
----
-apiVersion: tekton.dev/v1beta1
-kind: Task
-metadata:
-  name: cleanup
-spec:
-  description: This task will clean up a workspace by deleting all of the files.
+  description: This task will run nosetests on the provided input.
   workspaces:
     - name: source
+  params:
+    - name: args
+      description: Arguments to pass to nose
+      type: string
+      default: "-v"
+    - name: database_uri
+      description: Database connection string
+      type: string
+      default: "sqlite:///test.db"
   steps:
-    - name: remove
-      image: alpine:3
-      env:
-        - name: WORKSPACE_SOURCE_PATH
-          value: $(workspaces.source.path)
+    - name: nosetests
+      image: python:3.9-slim
       workingDir: $(workspaces.source.path)
-      securityContext:
-        runAsNonRoot: false
-        runAsUser: 0
+      env:
+        - name: DATABASE_URI
+          value: $(params.database_uri)
       script: |
-        #!/usr/bin/env sh
-        set -eu
-        echo "Removing all files from ${WORKSPACE_SOURCE_PATH} ..."
-        # Delete any existing contents of the directory if it exists.
-        #
-        # We don't just "rm -rf ${WORKSPACE_SOURCE_PATH}" because ${WORKSPACE_SOURCE_PATH} might be "/"
-        # or the root of a mounted volume.
-        if [ -d "${WORKSPACE_SOURCE_PATH}" ] ; then
-          # Delete non-hidden files and directories
-          rm -rf "${WORKSPACE_SOURCE_PATH:?}"/*
-          # Delete files and directories starting with . but excluding ..
-          rm -rf "${WORKSPACE_SOURCE_PATH}"/.[!.]*
-          # Delete files and directories starting with .. plus any other character
-          rm -rf "${WORKSPACE_SOURCE_PATH}"/..?*
-        fi
+        #!/bin/bash
+        set -e
 
+        echo "***** Installing dependencies *****"
+        python -m pip install --upgrade pip wheel
+        pip install -qr requirements.txt
+
+        echo "***** Running nosetests with: $(params.args)"
+        nosetests $(params.args)


### PR DESCRIPTION
This pull request includes significant changes to the `tekton/tasks.yaml` file, primarily transforming the existing tasks and adding new parameters to support running `nosetests`.

Changes to `tekton/tasks.yaml`:

* Renamed the task from `echo` to `nose` and updated the description to indicate that the task will run `nosetests` on the provided input.
* Added new parameters `args` and `database_uri` to pass arguments to `nose` and provide a database connection string, respectively.
* Updated the task steps to use the `python:3.9-slim` image, set the working directory, and run `nosetests` with the specified arguments.
* Removed the old `cleanup` task and its associated steps for deleting files from a workspace.